### PR TITLE
Use get function to check if a "role" is enabled

### DIFF
--- a/grafana/client.sls
+++ b/grafana/client.sls
@@ -1,5 +1,5 @@
 {%- from "grafana/map.jinja" import client with context %}
-{%- if client.enabled %}
+{%- if client.get('enabled', False) %}
 
 /etc/salt/minion.d/_grafana.conf:
   file.managed:

--- a/grafana/collector.sls
+++ b/grafana/collector.sls
@@ -1,5 +1,5 @@
 {%- from "grafana/map.jinja" import collector with context %}
-{%- if collector.enabled %}
+{%- if collector.get('enabled', False) %}
 
 grafana_grains_dir:
   file.directory:

--- a/grafana/server.sls
+++ b/grafana/server.sls
@@ -1,5 +1,5 @@
 {%- from "grafana/map.jinja" import server with context %}
-{%- if server.enabled %}
+{%- if server.get('enabled', False) %}
 
 grafana_packages:
   pkg.installed:


### PR DESCRIPTION
This patch uses the function get with False by default. This is to allow
to call a state even if the node is not classified.