### PR TITLE
Move the configuration into a separate state

### DIFF
--- a/grafana/client/init.sls
+++ b/grafana/client/init.sls
@@ -1,12 +1,8 @@
 {%- from "grafana/map.jinja" import client with context %}
 {%- if client.get('enabled', False) %}
 
-/etc/salt/minion.d/_grafana.conf:
-  file.managed:
-  - source: salt://grafana/files/_grafana.conf
-  - template: jinja
-  - user: root
-  - group: root
+include:
+  - grafana.client.service
 
 {%- for datasource_name, datasource in client.datasource.iteritems() %}
 

--- a/grafana/client/service.sls
+++ b/grafana/client/service.sls
@@ -1,0 +1,11 @@
+{%- from "grafana/map.jinja" import client with context %}
+{%- if client.get('enabled', False) %}
+
+/etc/salt/minion.d/_grafana.conf:
+  file.managed:
+  - source: salt://grafana/files/_grafana.conf
+  - template: jinja
+  - user: root
+  - group: root
+
+{%- endif %}


### PR DESCRIPTION
This patch separates the configuration of Grafana client. This allows to
configure the client, restart the minion to read the conf and finally
apply the grafana.client.state.