### PR TITLE
Pass the main dashboard through grains

### DIFF
--- a/grafana/files/grafana_dashboards/main_influxdb.json
+++ b/grafana/files/grafana_dashboards/main_influxdb.json
@@ -526,7 +526,7 @@
                 {
                   "key": "cluster_name",
                   "operator": "=",
-                  "value": "neutron-control-plane"
+                  "value": "neutron-control"
                 }
               ]
             }
@@ -661,7 +661,7 @@
                 {
                   "key": "cluster_name",
                   "operator": "=",
-                  "value": "nova-control-plane"
+                  "value": "nova-control"
                 }
               ]
             }
@@ -796,7 +796,7 @@
                 {
                   "key": "cluster_name",
                   "operator": "=",
-                  "value": "cinder-control-plane"
+                  "value": "cinder-control"
                 }
               ]
             }
@@ -848,141 +848,6 @@
       "editable": true,
       "height": "250px",
       "panels": [
-        {
-          "cacheTimeout": null,
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(71, 212, 59, 0.4)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(225, 40, 40, 0.59)"
-          ],
-          "datasource": null,
-          "editable": true,
-          "error": false,
-          "format": "none",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "id": 27,
-          "interval": "> 60s",
-          "links": [
-            {
-              "dashboard": "Neutron",
-              "name": "Drilldown dashboard",
-              "title": "Neutron",
-              "type": "dashboard"
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "span": 2,
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-          },
-          "targets": [
-            {
-              "column": "value",
-              "condition": "",
-              "dsType": "influxdb",
-              "fill": "",
-              "function": "last",
-              "groupBy": [
-                {
-                  "params": [
-                    "$interval"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "null"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "groupByTags": [],
-              "groupby_field": "",
-              "interval": "",
-              "measurement": "cluster_status",
-              "policy": "default",
-              "query": "SELECT last(\"value\") FROM \"cluster_status\" WHERE \"cluster_name\" = 'neutron' AND $timeFilter GROUP BY time($interval) fill(null)",
-              "rawQuery": false,
-              "refId": "A",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "value"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "last"
-                  }
-                ]
-              ],
-              "tags": [
-                {
-                  "key": "cluster_name",
-                  "operator": "=",
-                  "value": "neutron-data-plane"
-                }
-              ]
-            }
-          ],
-          "thresholds": "1,3",
-          "title": "Neutron",
-          "type": "singlestat",
-          "valueFontSize": "50%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "no data",
-              "value": "null"
-            },
-            {
-              "op": "=",
-              "text": "OKAY",
-              "value": "0"
-            },
-            {
-              "op": "=",
-              "text": "WARN",
-              "value": "1"
-            },
-            {
-              "op": "=",
-              "text": "UNKW",
-              "value": "2"
-            },
-            {
-              "op": "=",
-              "text": "CRIT",
-              "value": "3"
-            },
-            {
-              "op": "=",
-              "text": "DOWN",
-              "value": "4"
-            }
-          ],
-          "valueName": "current"
-        },
         {
           "cacheTimeout": null,
           "colorBackground": true,
@@ -1075,7 +940,7 @@
                 {
                   "key": "cluster_name",
                   "operator": "=",
-                  "value": "nova-data-plane"
+                  "value": "nova-data"
                 }
               ]
             }
@@ -1333,7 +1198,7 @@
                 {
                   "key": "cluster_name",
                   "operator": "=",
-                  "value": "cinder-data-plane"
+                  "value": "cinder-data"
                 }
               ]
             }
@@ -1685,10 +1550,10 @@
           "interval": ">60s",
           "links": [
             {
-              "dashUri": "db/apache",
-              "dashboard": "Apache",
+              "dashUri": "db/nginx",
+              "dashboard": "Nginx",
               "name": "Drilldown dashboard",
-              "title": "Apache",
+              "title": "Nginx",
               "type": "dashboard"
             }
           ],
@@ -1730,7 +1595,7 @@
               "interval": "",
               "measurement": "cluster_status",
               "policy": "default",
-              "query": "SELECT last(\"value\") FROM \"cluster_status\" WHERE \"cluster_name\" = 'apache' AND $timeFilter GROUP BY time($interval) fill(null)",
+              "query": "SELECT last(\"value\") FROM \"cluster_status\" WHERE \"cluster_name\" = 'nginx' AND $timeFilter GROUP BY time($interval) fill(null)",
               "rawQuery": false,
               "refId": "A",
               "resultFormat": "time_series",
@@ -1757,13 +1622,13 @@
                 {
                   "key": "cluster_name",
                   "operator": "=",
-                  "value": "apache"
+                  "value": "nginx"
                 }
               ]
             }
           ],
           "thresholds": "1,3",
-          "title": "Apache",
+          "title": "Nginx",
           "type": "singlestat",
           "valueFontSize": "50%",
           "valueMaps": [
@@ -2042,132 +1907,6 @@
           ],
           "thresholds": "1,3",
           "title": "memcached",
-          "type": "singlestat",
-          "valueFontSize": "50%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "no data",
-              "value": "null"
-            },
-            {
-              "op": "=",
-              "text": "OKAY",
-              "value": "0"
-            },
-            {
-              "op": "=",
-              "text": "WARN",
-              "value": "1"
-            },
-            {
-              "op": "=",
-              "text": "UNKW",
-              "value": "2"
-            },
-            {
-              "op": "=",
-              "text": "CRIT",
-              "value": "3"
-            },
-            {
-              "op": "=",
-              "text": "DOWN",
-              "value": "4"
-            }
-          ],
-          "valueName": "current"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(71, 212, 59, 0.4)",
-            "rgba(245, 150, 40, 0.73)",
-            "rgba(225, 40, 40, 0.59)"
-          ],
-          "datasource": null,
-          "editable": true,
-          "error": false,
-          "format": "short",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "id": 29,
-          "interval": ">60s",
-          "links": [],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "span": 2,
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-          },
-          "targets": [
-            {
-              "column": "value",
-              "dsType": "influxdb",
-              "fill": "",
-              "function": "last",
-              "groupBy": [
-                {
-                  "params": [
-                    "$interval"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "null"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "groupByTags": [],
-              "interval": "",
-              "measurement": "cluster_status",
-              "policy": "default",
-              "query": "SELECT last(\"value\") FROM \"cluster_status\" WHERE \"cluster_name\" = 'memcached' AND $timeFilter GROUP BY time($interval) fill(null)",
-              "rawQuery": false,
-              "refId": "A",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "value"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "last"
-                  }
-                ]
-              ],
-              "tags": [
-                {
-                  "key": "cluster_name",
-                  "operator": "=",
-                  "value": "pacemaker"
-                }
-              ]
-            }
-          ],
-          "thresholds": "1,3",
-          "title": "pacemaker",
           "type": "singlestat",
           "valueFontSize": "50%",
           "valueMaps": [

--- a/grafana/meta/grafana.yml
+++ b/grafana/meta/grafana.yml
@@ -1,45 +1,4 @@
-{%- if pillar.get('grafana').collector is defined %}
 dashboard:
-  test-single-{{ grains.host }}:
-    title: Dashboard single {{ grains.host }}
-    editable: true
-    hideControls: false
-    row:
-      single:
-        title: Single row
-        height: 250px
-        showTitle: true
-        panel:
-          first:
-            title: Single Panel
-            span: 8
-            editable: false
-            type: graph
-            target:
-              A:
-                refId: A
-                target: "support_prd.cfg01_iot_tcpcloud_eu.cpu.0.idle"
-            datasource: graphite01
-            renderer: flot
-  test-merge:
-    title: Dashboard merge
-    editable: true
-    hideControls: false
-    row:
-      merge:
-        showTitle: true
-        title: Merge
-        height: 250px
-        panel:
-          merge:
-            title: Merge Panel
-            span: 8
-            editable: false
-            type: graph
-            target:
-              {{ grains.host }}:
-                refId: A
-                target: "support_prd.cfg01_iot_tcpcloud_eu.cpu.0.idle"
-            datasource: graphite01
-            renderer: flot
-{%- endif %}
+  main:
+    format: json
+    template: grafana/files/grafana_dashboards/main_influxdb.json

--- a/metadata/service/support.yml
+++ b/metadata/service/support.yml
@@ -9,3 +9,5 @@ parameters:
         enabled: false
       sphinx:
         enabled: true
+      grafana:
+        enabled: true


### PR DESCRIPTION
This patch provides the main dashboard through mine. It is not the final
way to provide the main dashboard. It is more a workaround because we
don't know yet how to compose a dashboards with pieces split between
several formulas. We will probably use YAML pieces.